### PR TITLE
Replaced yii\bootstrap4 with a yii\bootstrap5

### DIFF
--- a/assets/AppAssets.php
+++ b/assets/AppAssets.php
@@ -42,7 +42,7 @@ class AppAssets extends AssetBundle
     public $depends = [
         'yii\web\YiiAsset',
         'yii\widgets\ActiveFormAsset',
-        'yii\bootstrap4\BootstrapAsset',
+        'yii\bootstrap5\BootstrapAsset',
     ];
 
     /**

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -1,5 +1,5 @@
 <?php
-use yii\bootstrap4\ActiveForm;
+use yii\bootstrap5\ActiveForm;
 use yii\helpers\Html;
 
 /** @var $model c006\utility\migration\models\MigrationUtility */


### PR DESCRIPTION
Replaced yii\bootstrap version from 4 to 5 to support current Yii 2.0.46+ versions